### PR TITLE
Add inbound message querying to message sender client

### DIFF
--- a/seed_services_client/message_sender.py
+++ b/seed_services_client/message_sender.py
@@ -31,6 +31,12 @@ class MessageSenderApiClient(object):
     def get_outbounds(self, params=None):
         return self.session.get('/outbound/', params=params)
 
+    def create_inbound(self, payload):
+        return self.session.post('/inbound/', data=payload)
+
+    def get_inbounds(self, params=None):
+        return self.session.get('/inbound/', params=params)
+
     def get_failed_tasks(self, params=None):
         return self.session.get('/failed-tasks/', params=params)
 

--- a/seed_services_client/tests/test_identity_store.py
+++ b/seed_services_client/tests/test_identity_store.py
@@ -263,7 +263,6 @@ class TestIdentityStoreClient(TestCase):
         }
         # Execute
         result = self.api.update_identity(uid, data)
-        print(result)
         # Check
         self.assertEqual(result["id"], uid)
         self.assertEqual(result["version"], 1)

--- a/seed_services_client/tests/test_message_sender.py
+++ b/seed_services_client/tests/test_message_sender.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
+import json
 import responses
+import re
 
 from seed_services_client.message_sender \
     import MessageSenderApiClient
@@ -10,6 +12,27 @@ class TestMessageSenderClient(TestCase):
     def setUp(self):
         self.api = MessageSenderApiClient(
             "NO", "http://ms.example.org/api/v1")
+
+    @responses.activate
+    def test_create_inbound(self):
+        # Catch all requests
+        responses.add(
+            responses.POST, re.compile(r'.*'), json={'test': 'response'},
+            status=200)
+
+        inbound_payload = {
+            'from_addr': '+1234'
+        }
+
+        response = self.api.create_inbound(inbound_payload)
+
+        # Check
+        self.assertEqual(response, {'test': 'response'})
+        self.assertEqual(len(responses.calls), 1)
+        request = responses.calls[0].request
+        self.assertEqual(request.method, 'POST')
+        self.assertEqual(request.url, "http://ms.example.org/api/v1/inbound/")
+        self.assertEqual(json.loads(request.body), inbound_payload)
 
     @responses.activate
     def test_create_outbound(self):
@@ -73,4 +96,23 @@ class TestMessageSenderClient(TestCase):
         self.assertEqual(
             responses.calls[0].request.url,
             "http://ms.example.org/api/v1/outbound/"
+        )
+
+    @responses.activate
+    def test_get_inbounds(self):
+        # Catch all requests
+        responses.add(
+            responses.GET, re.compile(r'.*'), json={'test': 'response'},
+            status=200)
+
+        # Execute
+        response = self.api.get_inbounds({'from_addr': '+1234'})
+
+        # Check
+        self.assertEqual(response, {'test': 'response'})
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(responses.calls[0].request.method, 'GET')
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "http://ms.example.org/api/v1/inbound/?from_addr=%2B1234"
         )


### PR DESCRIPTION
The list and create endpoints for inbound messages are available on the API, but not on the client.

We should add them.