### PR TITLE
[SEED-909] Add method to get address for identity

### DIFF
--- a/seed_services_client/identity_store.py
+++ b/seed_services_client/identity_store.py
@@ -41,6 +41,18 @@ class IdentityStoreApiClient(SeedServicesApiClient):
         params = {"details__addresses__%s" % address_type: address_value}
         return self.session.get('/identities/search/', params=params)
 
+    def get_identity_address(self, identity_id, address_type='msisdn'):
+        params = {'default': True}
+
+        response = self.session.get(
+            '/identities/{0}/addresses/{1}'.format(identity_id, address_type),
+            params=params)
+
+        if len(response["results"]) > 0:
+            return response["results"][0]["address"]
+        else:
+            return None
+
     def update_identity(self, identity, data=None):
         return self.session.patch('/identities/%s/' % identity, data=data)
 

--- a/seed_services_client/tests/test_identity_store.py
+++ b/seed_services_client/tests/test_identity_store.py
@@ -177,6 +177,39 @@ class TestIdentityStoreClient(TestCase):
                          "http://id.example.org/api/v1/identities/%s/" % uid)
 
     @responses.activate
+    def test_get_identity_address(self):
+        # Setup
+        uid = 'uid'
+        url = ('http://id.example.org/api/v1/identities/{0}'
+               '/addresses/msisdn?default=True').format(uid)
+        addresses_msisdn_response = {'results': [
+            {'address': '+27000000000'},
+            {'address': '+27000000001'},
+        ]}
+        responses.add(responses.GET, url,
+                      json=addresses_msisdn_response, status=200,
+                      match_querystring=True)
+        # Execute
+        result = self.api.get_identity_address(identity_id=uid)
+        # Check
+        self.assertEqual(result, '+27000000000')
+
+    @responses.activate
+    def test_get_identity_address_no_results(self):
+        # Setup
+        uid = 'uid'
+        url = ('http://id.example.org/api/v1/identities/{0}'
+               '/addresses/msisdn?default=True').format(uid)
+        addresses_msisdn_response = {'results': []}
+        responses.add(responses.GET, url,
+                      json=addresses_msisdn_response, status=200,
+                      match_querystring=True)
+        # Execute
+        result = self.api.get_identity_address(identity_id=uid)
+        # Check
+        self.assertEqual(result, None)
+
+    @responses.activate
     def test_identity_list_no_results(self):
         # setup
         response = {


### PR DESCRIPTION
The `address_type` could be parameterised in future but right now I've only seen cases where it's set to `msisdn`.