### PR TITLE
Add retry functionality

### DIFF
--- a/seed_services_client/identity_store.py
+++ b/seed_services_client/identity_store.py
@@ -1,7 +1,7 @@
-from demands import JSONServiceClient
+from .seed_services import SeedServicesApiClient
 
 
-class IdentityStoreApiClient(object):
+class IdentityStoreApiClient(SeedServicesApiClient):
     """
     Client for Identity Store Service.
 
@@ -16,12 +16,9 @@ class IdentityStoreApiClient(object):
 
     """
 
-    def __init__(self, auth_token, api_url, session=None):
-        headers = {'Authorization': 'Token ' + auth_token}
-        if session is None:
-            session = JSONServiceClient(url=api_url,
-                                        headers=headers)
-        self.session = session
+    def __init__(self, auth_token, api_url, session=None, **kwargs):
+        super(IdentityStoreApiClient, self).__init__(
+            auth_token, api_url, session=session, **kwargs)
 
     def get_identities(self, params=None):
         return self.session.get('/identities/', params=params)

--- a/seed_services_client/identity_store.py
+++ b/seed_services_client/identity_store.py
@@ -6,11 +6,13 @@ class IdentityStoreApiClient(object):
     Client for Identity Store Service.
 
     :param str auth_token:
-
         An access token.
 
     :param str api_url:
         The full URL of the API.
+
+    :param JSONServiceClient session:
+        An instance of JSONServiceClient to use
 
     """
 

--- a/seed_services_client/seed_services.py
+++ b/seed_services_client/seed_services.py
@@ -15,20 +15,20 @@ class SeedServicesApiClient(object):
     :param JSONServiceClient session:
         An instance of JSONServiceClient to use
 
-    :param bool retry:
-        Boolean indicating whether failed requests should be retried
+    :param retries:
+        (optional) The number of times to retry an HTTP request
 
     """
 
-    def __init__(self, auth_token, api_url, session=None, retry=False):
+    def __init__(self, auth_token, api_url, session=None, retries=0):
         headers = {'Authorization': 'Token ' + auth_token}
         if session is None:
             session = JSONServiceClient(url=api_url,
                                         headers=headers)
         self.session = session
 
-        if retry:
-            http = HTTPAdapter(max_retries=5)
-            https = HTTPAdapter(max_retries=5)
+        if retries > 0:
+            http = HTTPAdapter(max_retries=retries)
+            https = HTTPAdapter(max_retries=retries)
             self.session.mount('http://', http)
             self.session.mount('https://', https)

--- a/seed_services_client/seed_services.py
+++ b/seed_services_client/seed_services.py
@@ -1,0 +1,34 @@
+from demands import JSONServiceClient
+from requests.adapters import HTTPAdapter
+
+
+class SeedServicesApiClient(object):
+    """
+    Base API client for seed services.
+
+    :param str auth_token:
+        An access token.
+
+    :param str api_url:
+        The full URL of the API.
+
+    :param JSONServiceClient session:
+        An instance of JSONServiceClient to use
+
+    :param bool retry:
+        Boolean indicating whether failed requests should be retried
+
+    """
+
+    def __init__(self, auth_token, api_url, session=None, retry=False):
+        headers = {'Authorization': 'Token ' + auth_token}
+        if session is None:
+            session = JSONServiceClient(url=api_url,
+                                        headers=headers)
+        self.session = session
+
+        if retry:
+            http = HTTPAdapter(max_retries=5)
+            https = HTTPAdapter(max_retries=5)
+            self.session.mount('http://', http)
+            self.session.mount('https://', https)

--- a/seed_services_client/tests/test_identity_store.py
+++ b/seed_services_client/tests/test_identity_store.py
@@ -1,13 +1,25 @@
+from mock import patch
 from unittest import TestCase
 import responses
 
 from seed_services_client.identity_store import IdentityStoreApiClient
+from seed_services_client.seed_services import SeedServicesApiClient
 
 
 class TestIdentityStoreClient(TestCase):
 
     def setUp(self):
         self.api = IdentityStoreApiClient("NO", "http://id.example.org/api/v1")
+
+    @patch("seed_services_client.seed_services.SeedServicesApiClient.__init__")
+    def test_inherited_from_base_api_class(self, mock_parent_init):
+        self.assertTrue(
+            issubclass(IdentityStoreApiClient, SeedServicesApiClient))
+
+        IdentityStoreApiClient(
+            'token', 'http://api/', session='session', argument=True)
+        mock_parent_init.assert_called_with(
+            'token', 'http://api/', session='session', argument=True)
 
     @responses.activate
     def test_identity_search(self):

--- a/seed_services_client/tests/test_seed_services.py
+++ b/seed_services_client/tests/test_seed_services.py
@@ -1,0 +1,14 @@
+from unittest import TestCase
+
+from seed_services_client.seed_services import SeedServicesApiClient
+
+
+class TestSeedServicesApiClient(TestCase):
+
+    def test_retry_requests(self):
+        self.api = SeedServicesApiClient("token", "http://api/", retry=True)
+
+        self.assertEqual(
+            self.api.session.adapters['https://'].max_retries.total, 5)
+        self.assertEqual(
+            self.api.session.adapters['http://'].max_retries.total, 5)

--- a/seed_services_client/tests/test_seed_services.py
+++ b/seed_services_client/tests/test_seed_services.py
@@ -5,8 +5,16 @@ from seed_services_client.seed_services import SeedServicesApiClient
 
 class TestSeedServicesApiClient(TestCase):
 
-    def test_retry_requests(self):
-        self.api = SeedServicesApiClient("token", "http://api/", retry=True)
+    def test_number_of_retries_default(self):
+        self.api = SeedServicesApiClient("token", "http://api/")
+
+        self.assertEqual(
+            self.api.session.adapters['https://'].max_retries.total, 0)
+        self.assertEqual(
+            self.api.session.adapters['http://'].max_retries.total, 0)
+
+    def test_number_of_retries_can_be_configured(self):
+        self.api = SeedServicesApiClient("token", "http://api/", retries=5)
 
         self.assertEqual(
             self.api.session.adapters['https://'].max_retries.total, 5)


### PR DESCRIPTION
The hellomama-registration app retries HTTP/HTTPS requests - this should be the responsibility of this project.

I've created a base API class as I think there's likely to be a lot of duplication between the different clients.

Not sure whether this is too complicated or not, feedback welcome.