### PR TITLE
[SEED-909] Add timeout option to client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 demands==3.0.0
+requests==2.18.4

--- a/seed_services_client/seed_services.py
+++ b/seed_services_client/seed_services.py
@@ -2,6 +2,20 @@ from demands import JSONServiceClient
 from requests.adapters import HTTPAdapter
 
 
+class SeedHTTPAdapter(HTTPAdapter):
+    """
+    HTTPAdapter child class to implement global timeouts
+    """
+
+    def __init__(self, timeout=None, *args, **kwargs):
+        self.timeout = timeout
+        super(SeedHTTPAdapter, self).__init__(*args, **kwargs)
+
+    def send(self, *args, **kwargs):
+        kwargs['timeout'] = self.timeout
+        return super(SeedHTTPAdapter, self).send(*args, **kwargs)
+
+
 class SeedServicesApiClient(object):
     """
     Base API client for seed services.
@@ -18,17 +32,29 @@ class SeedServicesApiClient(object):
     :param retries:
         (optional) The number of times to retry an HTTP request
 
+    :param timeout:
+        (optional) The number of times to retry an HTTP request
+
     """
 
-    def __init__(self, auth_token, api_url, session=None, retries=0):
+    def __init__(self, auth_token, api_url, session=None, retries=0,
+                 timeout=None):
+
         headers = {'Authorization': 'Token ' + auth_token}
         if session is None:
             session = JSONServiceClient(url=api_url,
                                         headers=headers)
         self.session = session
 
+        http_adapter_kwargs = {}
+
         if retries > 0:
-            http = HTTPAdapter(max_retries=retries)
-            https = HTTPAdapter(max_retries=retries)
-            self.session.mount('http://', http)
-            self.session.mount('https://', https)
+            http_adapter_kwargs['max_retries'] = retries
+
+        if timeout is not None:
+            http_adapter_kwargs['timeout'] = timeout
+
+        http = SeedHTTPAdapter(**http_adapter_kwargs)
+        https = SeedHTTPAdapter(**http_adapter_kwargs)
+        self.session.mount('http://', http)
+        self.session.mount('https://', https)

--- a/seed_services_client/seed_services.py
+++ b/seed_services_client/seed_services.py
@@ -33,12 +33,13 @@ class SeedServicesApiClient(object):
         (optional) The number of times to retry an HTTP request
 
     :param timeout:
-        (optional) The number of times to retry an HTTP request
+        (optional) The number of seconds for a request to timeout,
+        defaults to 65 seconds
 
     """
 
     def __init__(self, auth_token, api_url, session=None, retries=0,
-                 timeout=None):
+                 timeout=65):
 
         headers = {'Authorization': 'Token ' + auth_token}
         if session is None:

--- a/seed_services_client/tests/test_seed_services.py
+++ b/seed_services_client/tests/test_seed_services.py
@@ -19,9 +19,9 @@ class TestSeedHTTPAdapter(TestCase):
 class TestSeedServicesApiClient(TestCase):
 
     @patch("seed_services_client.seed_services.SeedHTTPAdapter")
-    def test_timeout_not_passed_by_default(self, patch_adapter):
+    def test_timeout_default_if_unset(self, patch_adapter):
         self.api = SeedServicesApiClient("token", "http://api/")
-        patch_adapter.assert_called_with()
+        patch_adapter.assert_called_with(timeout=65)
 
     @patch("seed_services_client.seed_services.SeedHTTPAdapter")
     def test_timeout_passed_if_set(self, patch_adapter):

--- a/seed_services_client/tests/test_seed_services.py
+++ b/seed_services_client/tests/test_seed_services.py
@@ -1,9 +1,32 @@
+from mock import patch
 from unittest import TestCase
 
-from seed_services_client.seed_services import SeedServicesApiClient
+from seed_services_client.seed_services import (
+    SeedHTTPAdapter,
+    SeedServicesApiClient,
+)
+
+
+class TestSeedHTTPAdapter(TestCase):
+
+    @patch("requests.adapters.HTTPAdapter.send")
+    def test_calls_parent_class_send_with_timeout(self, patch_adapter_send):
+        adapter = SeedHTTPAdapter(timeout=10)
+        adapter.send()
+        patch_adapter_send.assert_called_with(timeout=10)
 
 
 class TestSeedServicesApiClient(TestCase):
+
+    @patch("seed_services_client.seed_services.SeedHTTPAdapter")
+    def test_timeout_not_passed_by_default(self, patch_adapter):
+        self.api = SeedServicesApiClient("token", "http://api/")
+        patch_adapter.assert_called_with()
+
+    @patch("seed_services_client.seed_services.SeedHTTPAdapter")
+    def test_timeout_passed_if_set(self, patch_adapter):
+        self.api = SeedServicesApiClient("token", "http://api/", timeout=5)
+        patch_adapter.assert_called_with(timeout=5)
 
     def test_number_of_retries_default(self):
         self.api = SeedServicesApiClient("token", "http://api/")


### PR DESCRIPTION
There are some places where we make use of varying timeouts when
making HTTP requests to Seed services.

There's no way to timeout a session - the requests devs are very
sure this isn't something they want to add because semantically
a session can't be timed out.

The recommend way to do this is to subclass HTTPAdapter. I've pinned
a specific version of requests as we now depend on an internal bit of
it.