### PR TITLE
Deepcopy headers

### DIFF
--- a/seed_services_client/seed_services.py
+++ b/seed_services_client/seed_services.py
@@ -1,3 +1,5 @@
+import copy
+
 from demands import HTTPServiceClient, JSONServiceClient
 from requests.adapters import HTTPAdapter
 
@@ -53,12 +55,12 @@ class SeedServicesApiClient(object):
 
         if session is None:
             session = JSONServiceClient(url=api_url,
-                                        headers=headers)
+                                        headers=copy.deepcopy(headers))
         self.session = session
 
         if session_http is None:
             session_http = HTTPServiceClient(url=api_url,
-                                             headers=headers)
+                                             headers=copy.deepcopy(headers))
 
         self.session_http = session_http
 

--- a/seed_services_client/tests/test_scheduler.py
+++ b/seed_services_client/tests/test_scheduler.py
@@ -141,7 +141,7 @@ class TestSchedulerApiClient(TestCase):
     @responses.activate
     def test_delete_schedule(self):
         schedule_id = "7bfffecf-abe8-4302-bd91-fd617e1c592e"
-        response = {}
+        response = {"foo": "bar"}
         responses.add(
             responses.DELETE,
             "http://example.org/api/v1/schedule/%s/" % (
@@ -150,5 +150,5 @@ class TestSchedulerApiClient(TestCase):
         # Execute
         result = self.api.delete_schedule(schedule_id)
         # Check
-        self.assertEqual(result, {})
+        self.assertEqual(result, {"foo": "bar"})
         self.assertEqual(len(responses.calls), 1)


### PR DESCRIPTION
The `headers` variable is mutable and is being changed by `JSONServiceClient` causing `HTTPServiceClient` to be created with the incorrect headers.